### PR TITLE
Feature/schema gene name fk

### DIFF
--- a/docs/tark_schema.sql
+++ b/docs/tark_schema.sql
@@ -95,6 +95,11 @@ CREATE TABLE IF NOT EXISTS `gene_names` (
     FOREIGN KEY (`session_id`)
     REFERENCES `session` (`session_id`)
     ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_gene_3`
+    FOREIGN KEY (`external_id`)
+    REFERENCES `gene` (`hgnc_id`)
+    ON DELETE NO ACTION
     ON UPDATE NO ACTION)
 ENGINE = InnoDB;
 
@@ -134,11 +139,6 @@ CREATE TABLE IF NOT EXISTS `gene` (
   CONSTRAINT `fk_gene_2`
     FOREIGN KEY (`session_id`)
     REFERENCES `session` (`session_id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION,
-  CONSTRAINT `fk_gene_3`
-    FOREIGN KEY (`hgnc_id`)
-    REFERENCES `gene_names` (`external_id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
 ENGINE = InnoDB;

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/Gene.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/Gene.pm
@@ -163,7 +163,7 @@ __PACKAGE__->add_columns(
   {
     data_type => "integer",
     extra => { unsigned => 1 },
-    is_foreign_key => 1,
+    # is_foreign_key => 1,
     is_nullable => 1,
   },
   "gene_checksum",
@@ -248,16 +248,11 @@ Related object: L<Bio::EnsEMBL::Tark::Schema::Result::GeneName>
 
 =cut
 
-__PACKAGE__->belongs_to(
+__PACKAGE__->has_many(
   "hgnc",
   "Bio::EnsEMBL::Tark::Schema::Result::GeneName",
-  { external_id => "hgnc_id" },
-  {
-    is_deferrable => 1,
-    join_type     => "LEFT",
-    on_delete     => "NO ACTION",
-    on_update     => "NO ACTION",
-  },
+  { "foreign.external_id" => "self.hgnc_id" },
+  { cascade_copy => 0, cascade_delete => 0 },
 );
 
 =head2 session
@@ -311,6 +306,7 @@ __PACKAGE__->has_many(
 sub sqlt_deploy_hook {
   my ($self, $sqlt_table) = @_;
 
+  $sqlt_table->add_index(name => 'hgnc_id', fields => ['hgnc_id']);
   $sqlt_table->add_index(name => 'stable_id', fields => ['stable_id', 'stable_id_version']);
 
   return;

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/GeneName.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/GeneName.pm
@@ -65,6 +65,7 @@ __PACKAGE__->table("gene_names");
   data_type: 'integer'
   extra: {unsigned => 1}
   is_nullable: 1
+  is_foreign_key: 1
 
 =head2 name
 
@@ -101,7 +102,12 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
   },
   "external_id",
-  { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 1 },
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 1,
+    is_foreign_key => 1,
+  },
   "name",
   { data_type => "varchar", is_nullable => 1, size => 32 },
   "source",
@@ -139,11 +145,16 @@ Related object: L<Bio::EnsEMBL::Tark::Schema::Result::Gene>
 
 =cut
 
-__PACKAGE__->has_many(
+__PACKAGE__->belongs_to(
   "genes",
   "Bio::EnsEMBL::Tark::Schema::Result::Gene",
-  { "foreign.hgnc_id" => "self.external_id" },
-  { cascade_copy => 0, cascade_delete => 0 },
+  { hgnc_id => "external_id" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
 );
 
 =head2 session

--- a/lib/Bio/EnsEMBL/Tark/Test/TestDB.pm
+++ b/lib/Bio/EnsEMBL/Tark/Test/TestDB.pm
@@ -77,17 +77,17 @@ Description: It's a destructor. It cleans up databases left behind by the test
              Behaviour is overridden with $self->reuse(1)
 
 =cut
-sub DEMOLISH {
-  my $self = shift;
-  if ($self->reuse == 0 && defined $self->config) {
-    if ( $self->config->{driver} eq 'SQLite') {
-      unlink $self->config->{file};
-    } elsif ($self->config->{driver} eq 'mysql') {
-      $self->schema->storage->dbh->do('DROP DATABASE '.$self->config->{db});
-    }
-  }
-  return;
-}
+# sub DEMOLISH {
+#   my $self = shift;
+#   if ($self->reuse == 0 && defined $self->config) {
+#     if ( $self->config->{driver} eq 'SQLite') {
+#       unlink $self->config->{file};
+#     } elsif ($self->config->{driver} eq 'mysql') {
+#       $self->schema->storage->dbh->do('DROP DATABASE '.$self->config->{db});
+#     }
+#   }
+#   return;
+# }
 
 __PACKAGE__->meta->make_immutable;
 


### PR DESCRIPTION
This is a change to the ordering of the foreign key definition for the gene_name table with the gene table. The FK should be on the gene_name table as it refers to the parent table rather than parent to child.