### PR TITLE
Feature/hgnc id name change

### DIFF
--- a/lib/Bio/EnsEMBL/Tark/HGNC.pm
+++ b/lib/Bio/EnsEMBL/Tark/HGNC.pm
@@ -83,7 +83,7 @@ SQL
   $self->set_query('gene' => $sth);
 
   my $update_ids_sql = (<<'SQL');
-    UPDATE gene SET hgnc_id = ? WHERE stable_id = ?
+    UPDATE gene SET name_id = ? WHERE stable_id = ?
 SQL
 
   $sth = $dbh->prepare( $update_ids_sql ) or

--- a/lib/Bio/EnsEMBL/Tark/HGNC.pm
+++ b/lib/Bio/EnsEMBL/Tark/HGNC.pm
@@ -110,8 +110,8 @@ sub flush_hgnc {
   $self->log()->info('Truncating gene names table');
   $dbh->do('TRUNCATE gene_names');
 
-  $self->log()->info('Setting hgnc_id column in the gene table to NULL');
-  $dbh->do('UPDATE gene SET hgnc_id = NULL');
+  $self->log()->info('Setting name_id column in the gene table to NULL');
+  $dbh->do('UPDATE gene SET name_id = NULL');
 
   return;
 } ## end sub flush_hgnc

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/Gene.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/Gene.pm
@@ -108,7 +108,7 @@ __PACKAGE__->table("gene");
   is_nullable: 1
   size: 20
 
-=head2 hgnc_id
+=head2 name_id
 
   data_type: 'integer'
   extra: {unsigned => 1}
@@ -159,12 +159,11 @@ __PACKAGE__->add_columns(
   { data_type => "varchar", is_nullable => 1, size => 42 },
   "loc_checksum",
   { data_type => "binary", is_nullable => 1, size => 20 },
-  "hgnc_id",
+  "name_id",
   {
-    data_type => "integer",
-    extra => { unsigned => 1 },
-    # is_foreign_key => 1,
+    data_type => "varchar",
     is_nullable => 1,
+    size => 32,
   },
   "gene_checksum",
   { data_type => "binary", is_nullable => 1, size => 20 },
@@ -240,7 +239,7 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
-=head2 hgnc
+=head2 name
 
 Type: belongs_to
 
@@ -249,9 +248,9 @@ Related object: L<Bio::EnsEMBL::Tark::Schema::Result::GeneName>
 =cut
 
 __PACKAGE__->has_many(
-  "hgnc",
+  "name",
   "Bio::EnsEMBL::Tark::Schema::Result::GeneName",
-  { "foreign.external_id" => "self.hgnc_id" },
+  { "foreign.external_id" => "self.name_id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
@@ -306,7 +305,7 @@ __PACKAGE__->has_many(
 sub sqlt_deploy_hook {
   my ($self, $sqlt_table) = @_;
 
-  $sqlt_table->add_index(name => 'hgnc_id', fields => ['hgnc_id']);
+  $sqlt_table->add_index(name => 'name_id', fields => ['name_id']);
   $sqlt_table->add_index(name => 'stable_id', fields => ['stable_id', 'stable_id_version']);
 
   return;

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/GeneName.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/GeneName.pm
@@ -103,8 +103,8 @@ __PACKAGE__->add_columns(
   },
   "external_id",
   {
-    data_type => "integer",
-    extra => { unsigned => 1 },
+    data_type => "varchar",
+    size => 32,
     is_nullable => 1,
     is_foreign_key => 1,
   },
@@ -148,7 +148,7 @@ Related object: L<Bio::EnsEMBL::Tark::Schema::Result::Gene>
 __PACKAGE__->belongs_to(
   "genes",
   "Bio::EnsEMBL::Tark::Schema::Result::Gene",
-  { hgnc_id => "external_id" },
+  { name_id => "external_id" },
   {
     is_deferrable => 1,
     join_type     => "LEFT",

--- a/lib/Bio/EnsEMBL/Tark/SpeciesLoader.pm
+++ b/lib/Bio/EnsEMBL/Tark/SpeciesLoader.pm
@@ -119,7 +119,7 @@ SQL
   my $gene_sql = (<<'SQL');
     INSERT INTO gene (
       stable_id, stable_id_version, assembly_id, loc_region, loc_start, loc_end,
-      loc_strand, loc_checksum, hgnc_id, gene_checksum, session_id)
+      loc_strand, loc_checksum, name_id, gene_checksum, session_id)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON DUPLICATE KEY UPDATE gene_id=LAST_INSERT_ID(gene_id)
 SQL

--- a/lib/t/hgnc_sql.t
+++ b/lib/t/hgnc_sql.t
@@ -79,7 +79,7 @@ $sql_handle->execute( 1000, 'ENSG00000101331' );
 my $result_count_01 = $test_utils->check_db(
   $db, 'Gene', { stable_id => 'ENSG00000101331' }
 );
-is( $result_count_01->hgnc_id, 1000, 'gene_update' );
+is( $result_count_01->name_id, 1000, 'gene_update' );
 
 done_testing();
 


### PR DESCRIPTION
Updated the name of the hgnc_id column to name_id and modified the type from integer to varchar(32) so that this can match the stable_id that is used by the naming consortium of choice.

Tests have also been updated to match the relevant code changes as well as code in the pipelines.