### PR TITLE
Feature/stats table

### DIFF
--- a/lib/Bio/EnsEMBL/Tark/Hive/PipeConfig/TarkLoaderReport_conf.pm
+++ b/lib/Bio/EnsEMBL/Tark/Hive/PipeConfig/TarkLoaderReport_conf.pm
@@ -132,6 +132,7 @@ sub pipeline_analyses {
         include_source => $self->o('include_source'),
 
         # Worker parameters
+        source_name            => $self->o( 'source_name' ),
         tag_shortname          => $self->o( 'tag_shortname' ),
         tag_previous_shortname => $self->o( 'tag_previous_shortname' ),
         report                 => $self->o( 'report' ),

--- a/lib/Bio/EnsEMBL/Tark/Hive/PipeConfig/TarkLoader_conf.pm
+++ b/lib/Bio/EnsEMBL/Tark/Hive/PipeConfig/TarkLoader_conf.pm
@@ -169,7 +169,7 @@ sub pipeline_analyses {
         tark_pass => $self->o( 'tark_pass' ),
         tark_db   => $self->o( 'tark_db' ),
 
-        source_name           => $self->o('source_name'),
+        source_name           => $self->o( 'source_name' ),
         naming_consortium     => $self->o( 'naming_consortium' ),
         add_consortium_prefix => $self->o( 'add_consortium_prefix' ),
       },
@@ -196,10 +196,11 @@ sub pipeline_analyses {
         tark_db   => $self->o( 'tark_db' ),
 
         # Include/Exclude db entries by source
-        exclude_source => $self->o('exclude_source'),
-        include_source => $self->o('include_source'),
+        exclude_source => $self->o( 'exclude_source' ),
+        include_source => $self->o( 'include_source' ),
 
         # Worker parameters
+        source_name            => $self->o( 'source_name' ),
         tag_shortname          => $self->o( 'tag_shortname' ),
         tag_previous_shortname => $self->o( 'tag_previous_shortname' ),
         report                 => $self->o( 'report' ),

--- a/lib/Bio/EnsEMBL/Tark/Hive/RunnableDB/TarkLoaderReport.pm
+++ b/lib/Bio/EnsEMBL/Tark/Hive/RunnableDB/TarkLoaderReport.pm
@@ -155,7 +155,9 @@ sub run {
       $sth = $tark_dbh->prepare( $tark_compare_sql );
       $sth->execute(
         $self->param( 'tag_previous_shortname' ),
-        $self->param( 'tag_shortname' )
+        $self->param( 'source_name' ),
+        $self->param( 'tag_shortname' ),
+        $self->param( 'source_name' )
       );
       my @tark_compare_removed = $sth->fetchrow_array();
       $output{ $table }{ 'removed' } = $tark_compare_removed[0];
@@ -164,10 +166,23 @@ sub run {
       $sth = $tark_dbh->prepare( $tark_compare_sql );
       $sth->execute(
         $self->param( 'tag_previous_shortname' ),
-        $self->param( 'tag_shortname' )
+        $self->param( 'source_name' ),
+        $self->param( 'tag_shortname' ),
+        $self->param( 'source_name' )
       );
       my @tark_compare_gained = $sth->fetchrow_array();
       $output{ $table }{ 'gained' } = $tark_compare_gained[0];
+
+      $tark_compare_sql = $tark_sql_handle->feature_diff_count( $table, 'changed' );
+      $sth = $tark_dbh->prepare( $tark_compare_sql );
+      $sth->execute(
+        $self->param( 'tag_previous_shortname' ),
+        $self->param( 'source_name' ),
+        $self->param( 'tag_shortname' ),
+        $self->param( 'source_name' )
+      );
+      my @tark_compare_gained = $sth->fetchrow_array();
+      $output{ $table }{ 'changed' } = $tark_compare_gained[0];
     }
   }
 

--- a/lib/Bio/EnsEMBL/Tark/Hive/RunnableDB/TarkLoaderReport.pm
+++ b/lib/Bio/EnsEMBL/Tark/Hive/RunnableDB/TarkLoaderReport.pm
@@ -181,16 +181,17 @@ sub run {
         $self->param( 'tag_shortname' ),
         $self->param( 'source_name' )
       );
-      my @tark_compare_gained = $sth->fetchrow_array();
-      $output{ $table }{ 'changed' } = $tark_compare_gained[0];
+      my @tark_compare_changed = $sth->fetchrow_array();
+      $output{ $table }{ 'changed' } = $tark_compare_changed[0];
     }
   }
 
-  open my $fh, '>', $self->param('report') or confess 'Can\'t open report file';
-
-  print $fh encode_json \%output;
-
-  close $fh or confess 'Can\'t close report file';
+  my $tark_report_sql = $tark_sql_handle->insert_stats(encode_json \%output);
+  my $sth = $tark_dbh->prepare( $tark_report_sql );
+  $sth->execute(
+    $self->param( 'source_name' ),
+    $self->param( 'tag_shortname' )
+  );
 
   return;
 }

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/ReleaseStats.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/ReleaseStats.pm
@@ -1,0 +1,156 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Tark::Schema::Result::ReleaseStats;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Bio::EnsEMBL::Tark::Schema::Result::ReleaseSource
+
+=cut
+
+use strict;
+use warnings;
+use utf8;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime");
+
+=head1 TABLE: C<release_stats>
+
+=cut
+
+__PACKAGE__->table("release_stats");
+
+=head1 ACCESSORSCREATE TABLE release_stats (
+  release_stats_id integer unsigned NOT NULL,
+  release_id integer unsigned NOT NULL,
+  json text NULL,
+  INDEX release_stats_idx_release_id (release_id),
+  PRIMARY KEY (release_stats_id),
+  CONSTRAINT release_stats_fk_release_id FOREIGN KEY (release_id) REFERENCES release_set (release_id) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB
+
+=head2 release_stats_id
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_auto_increment: 1
+  is_nullable: 0
+
+=head2 release_id
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 24
+
+=head2 json
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 256
+
+=cut
+
+__PACKAGE__->add_columns(
+  "release_stats_id",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_auto_increment => 1,
+    is_nullable => 0,
+  },
+  "release_id",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_nullable => 1,
+  },
+  "json",
+  { data_type => "longtext", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</release_stats_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("release_stats_id");
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<release_idx>
+
+=over 4
+
+=item * L</release_id>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("release_idx", ["release_id"]);
+
+=head1 RELATIONS
+
+=head2 release_set
+
+Type: belongs_to
+
+Related object: L<Bio::EnsEMBL::Tark::Schema::Result::ReleaseSet>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "release_set",
+  "Bio::EnsEMBL::Tark::Schema::Result::ReleaseSet",
+  { release_id => "release_id" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2019-01-22 14:34:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zxQttTG7klfBXtUwgDIIWQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/lib/t/db.t
+++ b/lib/t/db.t
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-See the NOTICE file distributed with this work for additional information
+   See the NOTICE file distributed with this work for additional information
    regarding copyright ownership.
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/t/hive_tarkloaderreport.t
+++ b/lib/t/hive_tarkloaderreport.t
@@ -28,6 +28,7 @@ use Test::More;
 use Data::Dumper;
 
 use Bio::EnsEMBL::Tark::Test::TestDB;
+use Bio::EnsEMBL::Tark::Test::Utils;
 use Bio::EnsEMBL::Test::MultiTestDB;
 
 use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob get_test_url_or_die make_new_db_from_sqls run_sql_on_db);
@@ -47,6 +48,8 @@ my $core_dba = $multi_db->get_DBAdaptor('core');
 my $tark_dba = Bio::EnsEMBL::Tark::Test::TestDB->new();
 $tark_dba->schema();
 
+my $test_utils = Bio::EnsEMBL::Tark::Test::Utils->new();
+
 standaloneJob(
   'Bio::EnsEMBL::Tark::Hive::RunnableDB::TarkLoader',
   {
@@ -63,6 +66,7 @@ standaloneJob(
     'tark_pass' => $tark_dba->config->{pass},
     'tark_db'   => $tark_dba->config->{db},
 
+    'source_name'      => 'Ensembl',
     'tag_block'        => 'release',
     'tag_shortname'    => 84,
     'tag_description'  => 'Ensembl release 84',
@@ -86,10 +90,16 @@ standaloneJob(
     'tark_pass' => $tark_dba->config->{pass},
     'tark_db'   => $tark_dba->config->{db},
 
+    'source_name'   => 'Ensembl',
     'tag_shortname' => 84,
     'report'        => 'test_report.json'
   },
 );
+
+my $result = $test_utils->check_db(
+  $tark_dba, 'ReleaseStats', {}, 1
+);
+is( $result, 1, 'Stats loaded into ReleaseStats' );
 
 standaloneJob(
   'Bio::EnsEMBL::Tark::Hive::RunnableDB::TarkLoaderReport',
@@ -106,12 +116,69 @@ standaloneJob(
     'tark_pass' => $tark_dba->config->{pass},
     'tark_db'   => $tark_dba->config->{db},
 
+    'source_name'   => 'sans_vega',
     'tag_shortname' => 84,
     'report'        => 'test_report_xvega.json',
 
     'exclude_source' => 'vega'
   },
 );
+
+
+
+standaloneJob(
+  'Bio::EnsEMBL::Tark::Hive::RunnableDB::TarkLoader',
+  {
+    'species'   => 'homo_sapiens',
+    'host' => $core_dba->dbc->host,
+    'port' => $core_dba->dbc->port,
+    'user' => $core_dba->dbc->user,
+    'pass' => $core_dba->dbc->pass,
+    'db'   => $core_dba->dbc->dbname,
+
+    'tark_host' => $tark_dba->config->{host},
+    'tark_port' => $tark_dba->config->{port},
+    'tark_user' => $tark_dba->config->{user},
+    'tark_pass' => $tark_dba->config->{pass},
+    'tark_db'   => $tark_dba->config->{db},
+
+    'source_name'      => 'Ensembl',
+    'tag_block'        => 'release',
+    'tag_shortname'    => 85,
+    'tag_description'  => 'Ensembl release 84',
+    'tag_feature_type' => 'all',
+  },
+);
+
+
+standaloneJob(
+  'Bio::EnsEMBL::Tark::Hive::RunnableDB::TarkLoaderReport',
+  {
+    'host' => $core_dba->dbc->host,
+    'port' => $core_dba->dbc->port,
+    'user' => $core_dba->dbc->user,
+    'pass' => $core_dba->dbc->pass,
+    'db'   => $core_dba->dbc->dbname,
+
+    'tark_host' => $tark_dba->config->{host},
+    'tark_port' => $tark_dba->config->{port},
+    'tark_user' => $tark_dba->config->{user},
+    'tark_pass' => $tark_dba->config->{pass},
+    'tark_db'   => $tark_dba->config->{db},
+
+    'source_name'   => 'Ensembl',
+    'tag_previous_shortname' => 84,
+    'tag_shortname' => 85,
+    'report'        => 'test_report.json'
+  },
+);
+
+$result = $test_utils->check_db(
+  $tark_dba, 'ReleaseStats', {}, 1
+);
+is( $result, 2, 'Stats loaded into ReleaseStats' );
+
+
 
 
 done_testing();

--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python
+
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import mysql.connector
+from mysql.connector import errorcode
+
+
+class tark_query:
+    """
+    Class related to handling the functions for interacting directly with the
+    HDF5 files. All required information should be passed to this class.
+    """
+
+    def __init__(self,
+                 host='localhost', port=3306, user='test', db='',
+                 source_name='Ensembl'):
+        """
+        Intialisation function for the tark datasets class
+
+        Parameters
+        ----------
+        host : str
+        port : int
+        user : str
+        db : str
+        scource_name : str
+            Source shortname used in the Tark DB release_source table
+        """
+
+        self.source_name = source_name
+
+        # Open database connection
+        self.dbc = mysql.connector.connect(
+            user=user,
+            host=host,
+            port=port,
+            database=db)
+
+    def get_set_names(self):
+        """
+        Get the list of release_set shortnames for the defined source
+
+        Returns
+        -------
+        shortnames : list of tuples
+        """
+        cursor = self.dbc.cursor()
+        sql = """
+            SELECT
+                rs.shortname
+            FROM
+                release_set AS rs
+                JOIN release_source AS rst ON (rs.source_id=rst.source_id)
+            WHERE
+                rst.shortname=%s;
+        """
+
+        try:
+            cursor.execute(sql, (self.source_name,))
+            return cursor.fetchall()
+        except mysql.connector.Error as err:
+            print('MySQL Error: ' + str(err))
+
+        return False
+
+    def feature_count(self, feature, set_name):
+        """
+        Get the counts for a feature with a given set shortnamename
+
+        Parameters
+        ----------
+        feature : str
+            This should be Gene|Transcript|Exon|Translation
+        set_name : str
+
+        Returns
+        -------
+        count : int
+        """
+
+        cursor = self.dbc.cursor()
+        sql = """
+            SELECT
+                COUNT(DISTINCT #FEATURE#.#FEATURE#_id)
+            FROM
+                #FEATURE#
+                JOIN #FEATURE#_release_tag AS f_tag ON (#FEATURE#.#FEATURE#_id=f_tag.feature_id)
+                JOIN release_set AS rs ON (f_tag.release_id=rs.release_id)
+                JOIN release_source AS rst ON (rs.source_id=rst.source_id)
+            WHERE
+                rst.shortname=%s AND
+                rs.shortname=%s;
+        """
+
+        try:
+            sql = sql.replace('#FEATURE#', feature)
+            cursor.execute(sql, (self.source_name, set_name,))
+            result = cursor.fetchall()
+            return result[0][0]
+        except mysql.connector.Error as err:
+            print('MySQL Error: ' + str(err))
+
+        return False
+
+    def feature_diff(self, feature, version, direction):
+        """
+        Get a count of the feature for a given release (addition, deletion or
+        change)
+
+        Parameters
+        ----------
+        feature : str
+        version : int
+        direction : str
+            One of gained|removed|changed
+
+        Returns
+        -------
+        count : int
+        """
+
+        cursor = self.dbc.cursor()
+
+        sql = """
+            SELECT
+                COUNT(*)
+            FROM
+                (
+                    SELECT
+                        #FEATURE#.stable_id,
+                        #FEATURE#.stable_id_version,
+                        f_tag.feature_id,
+                        rs.shortname,
+                        rs.description,
+                        rs.assembly_id
+                    FROM
+                        #FEATURE#
+                        JOIN #FEATURE#_release_tag AS f_tag ON (#FEATURE#.#FEATURE#_id=f_tag.feature_id)
+                        JOIN release_set AS rs ON (f_tag.release_id=rs.release_id)
+                        JOIN release_source AS rst ON (rs.source_id=rst.source_id)
+                    WHERE
+                        rs.shortname=%s AND
+                        rst.shortname=%s
+                ) AS v0
+                #DIRECTION# JOIN (
+                    SELECT
+                        #FEATURE#.stable_id,
+                        #FEATURE#.stable_id_version,
+                        f_tag.feature_id,
+                        rs.shortname,
+                        rs.description,
+                        rs.assembly_id
+                    FROM
+                        #FEATURE#
+                        JOIN #FEATURE#_release_tag AS f_tag ON (#FEATURE#.#FEATURE#_id=f_tag.feature_id)
+                        JOIN release_set AS rs ON (f_tag.release_id=rs.release_id)
+                        JOIN release_source AS rst ON (rs.source_id=rst.source_id)
+                    WHERE
+                        rs.shortname=%s AND
+                        rst.shortname=%s
+                ) AS v1 ON (v0.stable_id=v1.stable_id)
+            WHERE
+                #OUTER_WHERE#;
+        """
+
+        sql = sql.replace('#FEATURE#', feature)
+        if direction == 'removed':
+            sql = sql.replace('#DIRECTION#', 'LEFT')
+            sql = sql.replace('#OUTER_WHERE#', 'v1.stable_id IS NULL')
+        elif direction == 'gained':
+            sql = sql.replace('#DIRECTION#', 'RIGHT')
+            sql = sql.replace('#OUTER_WHERE#', 'v0.stable_id IS NULL')
+        else:
+            sql = sql.replace('#DIRECTION#', '')
+            sql = sql.replace(
+                '#OUTER_WHERE#',
+                'v0.stable_id_version!=v1.stable_id_version'
+            )
+
+        try:
+            cursor.execute(
+                sql,
+                (
+                    str(int(version)-1),
+                    self.source_name,
+                    str(version),
+                    self.source_name,
+                )
+            )
+            results = cursor.fetchall()
+            return results[0][0]
+        except mysql.connector.Error as err:
+            print('MySQL Error: ' + str(err))
+
+        return False
+
+    def generate_stats(self):
+        """
+        Generate the JSON blobs for stats between all releases for the source
+        defined in the object creation.
+
+        Returns
+        -------
+        list_of_dicts : list
+            Each dict object contains the summary stats for a given release
+        """
+
+        set_names = self.get_set_names()
+
+        stats_list = []
+        for set_name in set_names:
+            feature_stats = {
+                'release': {
+                    'previous': int(set_name[0])-1,
+                    'current': int(set_name[0])
+                }
+            }
+            for feature in ['gene', 'transcript', 'exon', 'translation']:
+                f_count = self.feature_count(feature, set_name[0])
+
+                f_removed = self.feature_diff(feature, set_name[0], 'removed')
+                f_gained = self.feature_diff(feature, set_name[0], 'gained')
+                f_changed = self.feature_diff(feature, set_name[0], 'changed')
+
+                feature_stats[feature] = {
+                    'tark_release': f_count,
+                    'removed': f_removed,
+                    'gained': f_gained,
+                    'changed': f_changed
+                }
+
+                print(feature, set_name[0], feature_stats[feature])
+
+            stats_list.append(feature_stats)
+
+        return stats_list
+
+
+class ensembl_query:
+    """
+    Class related to handling the functions for interacting directly with the
+    HDF5 files. All required information should be passed to this class.
+    """
+
+    def __init__(self, host='localhost', port=3306, user='test', db='',
+                 include='', exclude=''):
+        """
+        Intialisation function for accessing the ensembl databases
+
+        Parameters
+        ----------
+        host : str
+        port : int
+        user : str
+        db : str
+        """
+
+        # Open database connection
+        self.dbc = mysql.connector.connect(
+            user=user,
+            host=host,
+            port=port)
+
+        self.include = include
+        self.exclude = exclude
+
+    def feature_counts(self, db_name):
+        """
+        Get a random list of names to iterate through
+        """
+        cursor = self.dbc.cursor()
+
+        cursor.execute('USE ' + db_name)
+
+        f_counts = {}
+        for feature in ['gene', 'transcript', 'exon', 'translation']:
+            sql = """
+                SELECT
+                    COUNT(DISTINCT #FEATURE#.stable_id)
+                FROM
+                    #FROM#
+                #WHERE#;
+            """
+
+            params = []
+
+            where = ''
+            if self.include:
+                inc_list = self.include.split(',')
+                where = 'WHERE gene.source IN ( %s' + ', %s'*(len(inc_list)-1) + ' )'
+                params += inc_list
+            elif self.exclude:
+                exc_list = self.exclude.split(',')
+                where = 'WHERE gene.source NOT IN ( %s' + ', %s'*(len(exc_list)-1) + ' )'
+                params += exc_list
+
+            tables = feature
+            current_feature = feature
+            if feature == 'exon':
+                tables = """
+                    exon AS feature
+                    JOIN exon_transcript ON feature.exon_id=exon_transcript.exon_id
+                    JOIN transcript ON exon_transcript.transcript_id=transcript.transcript_id
+                    JOIN gene ON transcript.gene_id=gene.gene_id
+                """
+                current_feature = 'feature'
+            elif feature == 'transcript':
+                tables = """
+                    transcript AS feature
+                    JOIN gene ON feature.gene_id=gene.gene_id
+                """
+                current_feature = 'feature'
+            elif feature == 'translation':
+                tables = """
+                    translation AS feature
+                    JOIN transcript ON feature.transcript_id=transcript.transcript_id
+                    JOIN gene ON transcript.gene_id=gene.gene_id
+                """
+                current_feature = 'feature'
+
+            sql = sql.replace('#FEATURE#', current_feature)
+            sql = sql.replace('#FROM#', tables)
+            sql = sql.replace('#WHERE#', where)
+
+            try:
+                cursor.execute(sql, tuple(params))
+                f_counts[feature] = cursor.fetchall()
+            except mysql.connector.Error as err:
+                print('MySQL Error: ' + str(err))
+
+        return f_counts
+
+    def add_ensembl_counts(self, species, json_list):
+        """
+        """
+        cursor = self.dbc.cursor()
+
+        out_json = []
+
+        for json_obj in json_list:
+            try:
+                cursor.execute(
+                    'USE ensembl_production_' + str(
+                        json_obj['release']['current']
+                    )
+                )
+                sql = """
+                    SELECT
+                        full_db_name
+                    FROM
+                        db_list
+                    WHERE
+                        full_db_name LIKE '#SPECIES#_core\_%'
+                    ORDER BY db_id DESC
+                    LIMIT 1;
+                """
+                sql = sql.replace('#SPECIES#', species)
+                cursor.execute(sql)
+                dbs = cursor.fetchall()
+
+                print(dbs[0][0])
+                f_counts = self.feature_counts(dbs[0][0])
+
+                json_obj['gene']['core'] = f_counts['gene'][0][0]
+                json_obj['transcript']['core'] = f_counts['transcript'][0][0]
+                json_obj['exon']['core'] = f_counts['exon'][0][0]
+                json_obj['translation']['core'] = f_counts['translation'][0][0]
+            except mysql.connector.Error as err:
+                print(dbs[0][0])
+                print('MySQL Error: ' + str(err))
+
+            out_json.append(json_obj)
+
+        return out_json
+
+
+# ------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    # Set up the command line parameters
+    PARSER = argparse.ArgumentParser(description="Generate release statistics")
+    PARSER.add_argument(
+        "--host", help="Host")
+    PARSER.add_argument(
+        "--port", help="Port")
+    PARSER.add_argument(
+        "--user", help="Read Only username")
+    PARSER.add_argument(
+        "--db", help="Database")
+    PARSER.add_argument(
+        "--source",
+        help="Name of the source to generate stats for",
+        default=10)
+    PARSER.add_argument(
+        "--ehost", help="Ensembl Host")
+    PARSER.add_argument(
+        "--eport", help="Ensembl Port")
+    PARSER.add_argument(
+        "--euser", help="Read Only username")
+    PARSER.add_argument(
+        "--species", help="Ensembl species (eg homo_sapiens)")
+    PARSER.add_argument(
+        "--include",
+        help="Ensembl Include Sources",
+        default=None)
+    PARSER.add_argument(
+        "--exclude",
+        help="Ensembl Exclude Sources",
+        default=None)
+    PARSER.add_argument(
+        "--output",
+        help="Location of the outpout JSON file")
+
+    # Get the matching parameters from the command line
+    ARGS = PARSER.parse_args()
+
+    TARK_QUERY = tark_query(
+        host=ARGS.host,
+        port=ARGS.port,
+        user=ARGS.user,
+        db=ARGS.db,
+        source_name=ARGS.source
+    )
+
+    OUTPUT_JSON = TARK_QUERY.generate_stats()
+
+    ENSEMBL_QUERY = ensembl_query(
+        host=ARGS.ehost,
+        port=ARGS.eport,
+        user=ARGS.euser,
+        include=ARGS.include,
+        exclude=ARGS.exclude,
+    )
+
+    OUTPUT_JSON = ENSEMBL_QUERY.add_ensembl_counts(
+        species=ARGS.species,
+        json_list=OUTPUT_JSON
+    )
+
+    with open(ARGS.output, 'w') as f_out:
+        f_out.write(json.dumps(OUTPUT_JSON))

--- a/scripts/load_cores.sh
+++ b/scripts/load_cores.sh
@@ -108,6 +108,12 @@ then
   echo "Please specify only -e OR -i."
 fi
 
+TAG_DESCRITPION="Ensembl release ${RELEASE}"
+if [ "$ISOURCE" -gt "0" ]
+then
+  TAG_DESCRITPION="Ensembl release ${RELEASE} (${SOURCE_NAME})"
+fi
+
 eval $(mysql-ens-tark-dev-1-ensrw details env_TARK_)
 eval $(mysql-ens-hive-prod-2-ensrw details env_HIVE_)
 
@@ -148,7 +154,7 @@ do
     --core_user ${CORE_USER} --core_pass '' --core_dbname ${CORE_DB} \
     --host ${HIVE_HOST} --port ${HIVE_PORT} --user ${HIVE_USER} --password ${HIVE_PASS} \
     --pipeline_name ${HIVE_DB_NAME} --species ${SPECIES} \
-    --tag_block release --tag_shortname ${RELEASE} --tag_description "Ensembl release ${RELEASE}" \
+    --tag_block release --tag_shortname ${RELEASE} --tag_description "$TAG_DESCRITPION" \
     --tag_feature_type all --tag_version 1 \
     --block_size ${BATCH_COUNT} --report ${PWD}/loading_report_${RELEASE}.json \
     --tag_previous_shortname ${PREVIOUS_RELEASE} --source_name ${SOURCE_NAME} \


### PR DESCRIPTION
Stats are now loaded to a release_stats table within the Tark db.

The stats sets from the generate_stats.py script have been loaded in to the perl hive script that calculates the stats at the end of each run.

This one relies on PR #20, but also extends on and fixes a few minor issues.