### PR TITLE
Ea/764 biotype

### DIFF
--- a/docs/tark_schema.sql
+++ b/docs/tark_schema.sql
@@ -157,6 +157,8 @@ CREATE TABLE `gene` (
   `name_id` varchar(32) DEFAULT NULL,
   `gene_checksum` binary(20) DEFAULT NULL,
   `session_id` int(10) unsigned DEFAULT NULL,
+  /* change schema to add biotype */
+  `biotype` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
   UNIQUE KEY `gene_checksum_idx` (`gene_checksum`),
   KEY `gene_idx_assembly_id` (`assembly_id`),
@@ -489,6 +491,8 @@ CREATE TABLE `transcript` (
   `transcript_checksum` binary(20) DEFAULT NULL,
   `seq_checksum` binary(20) DEFAULT NULL,
   `session_id` int(10) unsigned DEFAULT NULL,
+  /* change schema to add biotype */
+  `biotype` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
   UNIQUE KEY `transcript_chk` (`transcript_checksum`),
   KEY `transcript_idx_assembly_id` (`assembly_id`),

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/Gene.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/Gene.pm
@@ -127,7 +127,13 @@ __PACKAGE__->table("gene");
   extra: {unsigned => 1}
   is_foreign_key: 1
   is_nullable: 1
+#populate biotype for gene
+=head2 biotype
 
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 40
+  
 =cut
 
 __PACKAGE__->add_columns(
@@ -175,6 +181,9 @@ __PACKAGE__->add_columns(
     is_foreign_key => 1,
     is_nullable => 1,
   },
+  # populate biotype for gene
+  "biotype",
+  { data_type => "varchar", is_nullable => 1, size => 40 },
 );
 
 =head1 PRIMARY KEY

--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/Transcript.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/Transcript.pm
@@ -134,6 +134,13 @@ __PACKAGE__->table("transcript");
   is_foreign_key: 1
   is_nullable: 1
 
+#populate biotype for transcript
+=head2 biotype
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 40
+  
 =cut
 
 __PACKAGE__->add_columns(
@@ -178,6 +185,9 @@ __PACKAGE__->add_columns(
     is_foreign_key => 1,
     is_nullable => 1,
   },
+  # populate biotype for transcript
+  "biotype",
+  { data_type => "varchar", is_nullable => 1, size => 40 }, 
 );
 
 =head1 PRIMARY KEY


### PR DESCRIPTION
This PR 5 covers [EA-764](https://www.ebi.ac.uk/panda/jira/browse/EA-764) and [EA-763](https://www.ebi.ac.uk/panda/jira/browse/EA-763)
1. https://www.ebi.ac.uk/panda/jira/browse/EA-764
Biotype work: Update Tark loader script to populate the biotype columns for Gene and Transcript

2. https://www.ebi.ac.uk/panda/jira/browse/EA-763
Biotype work: Update Tark schema to include "biotype" in the gene and transcript tables

Refer [confluence_page ](https://www.ebi.ac.uk/seqdb/confluence/display/EA/One+time+script+to+load+Biotype+in+gene+and+transcript+table) for scripts

The [Tark PR 28](https://github.com/Ensembl/tark/pull/28) covers following tickets
ea-644 - Display gene count in release stats
ea-766 - update tark UI to display biotype in gene & transcript
ea- 774 - add biotype to transcript details
