### PR TITLE
Ea/utr translation

### DIFF
--- a/docs/create_index.sql
+++ b/docs/create_index.sql
@@ -22,6 +22,8 @@ CREATE INDEX `fk_translation_2_idx` ON `translation` (`session_id` ASC);
 CREATE INDEX `fk_translation_3_idx` ON `translation` (`seq_checksum` ASC);
 CREATE INDEX `fk_translation_1_idx` ON `translation` (`assembly_id` ASC);
 CREATE INDEX `stable_id_version` ON `translation` (`stable_id` ASC, `stable_id_version` ASC);
+CREATE INDEX `fk_translation_five_utr_idx` ON `translation` (`five_utr_checksum` ASC);
+CREATE INDEX `fk_translation_three_utr_idx` ON `translation` (`three_utr_checksum` ASC);
 CREATE INDEX `fk_Tagset_1_idx` ON `tagset` (`session_id` ASC);
 CREATE INDEX `short_name_idx` ON `tagset` (`shortname` ASC);
 CREATE INDEX `transcript_id` ON `tag` (`transcript_id` ASC);

--- a/docs/tark_schema.sql
+++ b/docs/tark_schema.sql
@@ -592,6 +592,8 @@ CREATE TABLE `translation` (
   `translation_checksum` binary(20) DEFAULT NULL,
   `seq_checksum` binary(20) DEFAULT NULL,
   `session_id` int(10) unsigned DEFAULT NULL,
+  `five_utr_checksum` binary(40) DEFAULT NULL,
+  `three_utr_checksum` binary(40) DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
   UNIQUE KEY `translation_chk` (`translation_checksum`),
   KEY `translation_idx_assembly_id` (`assembly_id`),


### PR DESCRIPTION
EA-807
Tark loader script for adding 5' and 3' UTR checksum columns in translation table and updating its value.
for one-time loading of UTR checksum script: [please refer here](https://github.com/Ensembl/tark-configs/tree/master/utr_checksum)
db: ranjit_utr_tark_e75_to_e99

This is a new PR replacing the previous PR https://github.com/Ensembl/tark-loader/pull/24 which was reviewed by Sanjay with comments. 