### PR TITLE
Update loader scripts to use utr columns

### DIFF
--- a/lib/Bio/EnsEMBL/Tark/Schema/Result/Transcript.pm
+++ b/lib/Bio/EnsEMBL/Tark/Schema/Result/Transcript.pm
@@ -140,6 +140,48 @@ __PACKAGE__->table("transcript");
   data_type: 'varchar'
   is_nullable: 1
   size: 40
+
+=head2 three_prime_utr_start
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+=head2 three_prime_utr_end
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+=head2 three_prime_utr_seq
+  data_type: 'longtext'
+  is_nullable: 1
+
+=head2 three_prime_utr_checksum
+  data_type: 'binary'
+  is_nullable: 1
+  size: 20
+
+=head2 five_prime_utr_start
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+=head2 five_prime_utr_end
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+=head2 five_prime_utr_seq
+  data_type: 'longtext'
+  is_nullable: 1
+
+=head2 five_prime_utr_checksum
+  data_type: 'binary'
+  is_nullable: 1
+  size: 20
   
 =cut
 

--- a/lib/Bio/EnsEMBL/Tark/SpeciesLoader.pm
+++ b/lib/Bio/EnsEMBL/Tark/SpeciesLoader.pm
@@ -147,8 +147,10 @@ SQL
     INSERT INTO transcript (
       stable_id, stable_id_version, assembly_id, loc_region, loc_start, loc_end,
       loc_strand, loc_checksum, transcript_checksum, exon_set_checksum,
-      seq_checksum, session_id, biotype)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      seq_checksum, session_id, biotype, three_prime_utr_start, three_prime_utr_end,
+      three_prime_utr_seq, three_prime_utr_checksum, five_prime_utr_start,
+      five_prime_utr_end, five_prime_utr_seq, five_prime_utr_checksum)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
     ON DUPLICATE KEY UPDATE transcript_id=LAST_INSERT_ID(transcript_id)
 SQL
   $sth = $dbh->prepare( $transcript_sql );


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-807

This updates the loader scripts to write nulls into the new columns, which get populated later in the loading process.  I haven't tried running the loader script without these changes, so they may not be necessary.  I have checked that the pipeline does run successfully with these changes.