### PR TITLE
added biotype and slurm fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Makefile.old
 MANIFEST.bak
 pm_to_blib
 *~
+local/
+local

--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,7 @@ requires 'PerlIO::gzip';
 requires 'Proc::Daemon';
 requires 'SQL::Translator', '>= 0.11018';
 requires 'Text::CSV';
+requires 'DateTime::Format::ISO8601';
 requires 'Text::Glob';
 # requires 'URI::Escape';
 # requires 'XML::LibXML';

--- a/lib/Bio/EnsEMBL/Tark/Hive/PipeConfig/TarkLoader_conf.pm
+++ b/lib/Bio/EnsEMBL/Tark/Hive/PipeConfig/TarkLoader_conf.pm
@@ -107,6 +107,15 @@ sub default_options {
 
 =cut
 
+sub resource_classes {
+    my ($self) = @_;
+    return {
+        'default' => { SLURM => '--partition=production --time=1-00:00:00 --mem=4000' },
+        'default_slurm' => { SLURM => '--partition=production --time=1-00:00:00 --mem=4000' },
+        'default_16GB'    => { SLURM => '--partition=production --time=1-00:00:00 --mem=16000' },
+    };
+}
+
 sub pipeline_analyses {
   my ($self) = @_;
 

--- a/lib/Bio/EnsEMBL/Tark/SpeciesLoader.pm
+++ b/lib/Bio/EnsEMBL/Tark/SpeciesLoader.pm
@@ -349,7 +349,7 @@ sub _load_gene {
   }
 
   my $gene_checksum = $utils->checksum_array(
-    @loc_pieces, $name_id, $gene->stable_id(), $gene->version()
+    $loc_checksum, $name_id, $gene->stable_id(), $gene->version(), $gene->biotype()
   );
 
   my $sth = $self->get_insert('gene');
@@ -445,7 +445,7 @@ sub _load_transcript {
   my $utils = Bio::EnsEMBL::Tark::Utils->new();
   my $loc_checksum = $utils->checksum_array( @loc_pieces_checksum );
   my $transcript_checksum = $utils->checksum_array(
-    $loc_checksum, $transcript->stable_id(), $transcript->version(),
+    $loc_checksum, $transcript->stable_id(), $transcript->version(), $transcript->biotype(),
     (
       $session_pkg->{exon_set_checksum} ? $session_pkg->{exon_set_checksum} : undef
     ), $seq_checksum


### PR DESCRIPTION
This PR includes the following:

- Added biotype to the computation of checksums in the Tark loading process.
- Added ability to use Slurm when running Hive.

